### PR TITLE
Mtl cleanup

### DIFF
--- a/generator/ecore2pyecore.mtl
+++ b/generator/ecore2pyecore.mtl
@@ -93,14 +93,13 @@ eClass = EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
 [if (c.abstract)]@abstract
 [/if]
 [c.classHeader()/]
-    [for (a : EAttribute | c.eAttributes) after(if (c.eReferences->isEmpty()) then '\n' else '' endif)]
+    [if (c.eAttributes->size() + c.eReferences->size() + c.eAllAttributes->select(derived)->size() + c.eOperations->size() = 0)]
+    pass[/if][for (a : EAttribute | c.eAttributes) after(if (c.eReferences->isEmpty()) then '\n' else '' endif)]
     [a.generate()/]
     [/for]
     [for (r : EReference | c.eReferences) after('\n')]
     [r.name/] = EReference([r.referenceQualifiers()/])
-    [/for]
-    def __init__(self):
-        super().__init__()[for (d : EAttribute | c.eAllAttributes->select(derived)) before('\n\n') separator('\n\n')]
+    [/for][for (d : EAttribute | c.eAllAttributes->select(derived)) before('\n\n') separator('\n\n')]
     @property
     def [d.name/](self):
         return self._[d.name/]

--- a/generator/ecore2pyecore.mtl
+++ b/generator/ecore2pyecore.mtl
@@ -6,8 +6,7 @@
 
 [comment generate __init__/]
 [file (p.qualifiedPath() + '/' + '__init__.py', false, 'UTF-8')]
-import pyecore.ecore as Ecore
-from .[p.name/] import getEClassifier, eClassifiers
+from pyecore.ecore import eClassifiers
 from .[p.name/] import name, nsURI, nsPrefix, eClass
 from .[p.name/] import [p.eClassifiers.name->sep(', ')/]
 [if (p.eSuperPackage = null)]
@@ -60,7 +59,6 @@ for subpack in eSubpackages:
 [comment generate module /]
 [file (p.qualifiedPath() + '/' + p.name + '.py', false, 'UTF-8')]
 from pyecore.ecore import *
-import pyecore.ecore as Ecore
 [for (c : EClassifier | p.importFromOtherPackages()->sortedBy(ePackage.name))]
 from [c.ePackage.qualifiedName()/] import [c.name/]
 [/for]
@@ -70,7 +68,7 @@ name = '[p.name/]'
 nsURI = '[p.nsURI/]'
 nsPrefix = '[p.nsPrefix/]'
 
-eClass = Ecore.EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
+eClass = EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
 
 
 [for (c : EClassifier | p.eClassifiers->filter(EEnum))]


### PR DESCRIPTION
Tried to do a bit more template cleanup to make the generated code free of errors and most of the warnings:

* Fixed import statements, also removed the duplicate import of `ecore.*`and `as Ecore`.
* Removed the unneeded (or did I miss anything) implementation of `__init()`, added a `pass` if the class has no features at all.
